### PR TITLE
fix(security): remove unauthenticated /cors-proxy open proxy; add tzdata

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ FROM node:24-alpine
 WORKDIR /app
 
 # nginx (static + /api proxy + cors-proxy) and the runtime lib for better-sqlite3
-RUN apk add --no-cache nginx libstdc++
+RUN apk add --no-cache nginx libstdc++ tzdata
 
 ENV NODE_ENV=production
 ENV FRIRSS_DATA_DIR=/app/data

--- a/nginx.conf
+++ b/nginx.conf
@@ -23,37 +23,4 @@ server {
         expires 1y;
         add_header Cache-Control "public, immutable";
     }
-
-    # CORS proxy — for fetching external article pages (full content extraction)
-    location /cors-proxy/ {
-        resolver 1.1.1.1 8.8.8.8 valid=300s;
-        resolver_timeout 5s;
-
-        set $target_url '';
-
-        if ($request_uri ~* "^/cors-proxy/(.+)$") {
-            set $target_url $1;
-        }
-
-        proxy_pass $target_url;
-        proxy_ssl_server_name on;
-        proxy_set_header Accept-Encoding "";
-        proxy_set_header Host $proxy_host;
-        proxy_set_header User-Agent "Mozilla/5.0 (compatible; FriRSS/1.0)";
-
-        proxy_set_header Origin "";
-        proxy_set_header Referer "";
-
-        add_header Access-Control-Allow-Origin "*" always;
-        add_header Access-Control-Allow-Methods "GET, OPTIONS" always;
-        add_header Access-Control-Allow-Headers "Authorization, Content-Type" always;
-
-        if ($request_method = 'OPTIONS') {
-            add_header Access-Control-Allow-Origin "*";
-            add_header Access-Control-Allow-Methods "GET, OPTIONS";
-            add_header Access-Control-Allow-Headers "Authorization, Content-Type";
-            add_header Content-Length 0;
-            return 204;
-        }
-    }
 }


### PR DESCRIPTION
## Summary

Two small changes found while self-hosting:

1. **Remove the `/cors-proxy/` location block from nginx.conf** — it is an unauthenticated open proxy with no SSRF guard. Any URL can be fetched through it, including internal Docker hosts (`http://freshrss:80`, `http://172.x.x.x`) and cloud metadata endpoints. The frontend uses the guarded `/api/proxy` route (server/routes/proxy.ts, which has the internal-host allowlist) for full-content extraction, so this block is dead config and a security risk.

2. **Add `tzdata` to the production image** — without it the `TZ` env var is ignored (Alpine has no zoneinfo), so e.g. `TZ=Asia/Singapore` falls back to UTC.

## Changes

- `nginx.conf`: remove `/cors-proxy/` location (33 lines)
- `Dockerfile`: `apk add --no-cache nginx libstdc++ tzdata`

## Testing

- Built from source, verified `/cors-proxy` no longer reachable
- Verified `/api/proxy` still rejects internal targets (`Target host not allowed`)
- Verified `TZ=Asia/Singapore` → `date` reports +08